### PR TITLE
fix(mail): correct {{attachments}} path rendering

### DIFF
--- a/lib/mail.js
+++ b/lib/mail.js
@@ -22,6 +22,7 @@ const {
   APP_URL,
 } = process.env;
 
+const path = require('path');
 const dayjs = require('dayjs');
 const debug = require('debug')('mail');
 
@@ -30,7 +31,7 @@ const mailgun = require('mailgun-js')({
   domain: MAILGUN_DOMAIN_NAME,
 });
 
-const formatAsList = (file, idx) => `${idx + 1}.  ${file}`;
+const formatAsList = (file, idx) => `${idx + 1}.  ${path.parse(file).name}`;
 const r = str => new RegExp(str, 'g');
 
 /**
@@ -63,6 +64,8 @@ function compose(schedule, attachments) {
     },
   };
 
+  debug('templating the email into a sendable form.');
+
   // create an email based on the template submitted by the user.
   return template(body, data);
 }
@@ -77,6 +80,8 @@ function send(addresses, subject, body, attachments) {
     to: APP_EMAIL,
     'h:Reply-To': APP_EMAIL,
   };
+
+  debug('sending email via mailgun');
 
   return mailgun.messages().send(data);
 }


### PR DESCRIPTION
The attachments previously included the path on the filesystem, not just
the file names.  Now, only file names are displayed, without path
information or extension.