### PR TITLE
Implement pause feature for schedules

### DIFF
--- a/controllers/schedules.js
+++ b/controllers/schedules.js
@@ -110,4 +110,16 @@ router.get('/:id/trigger', (req, res) => {
   res.redirect('details');
 });
 
+
+router.get('/:id/pause', (req, res) => {
+  const schedule = db.getCollection('schedules').findOne({ id: req.params.id });
+  schedule.paused = !schedule.paused;
+
+  req.flash('success', schedule.paused ? req.t('SCHEDULES.UNPAUSE_SUCCESS') : req.t('SCHEDULES.PAUSE_SUCCESS'));
+  res.redirect('/schedules');
+
+  // queue a rescan of the fields in the database
+  attendant.flush();
+});
+
 module.exports = router;

--- a/lib/attendant.js
+++ b/lib/attendant.js
@@ -83,6 +83,12 @@ function scan() {
       dequeue(id);
     }
 
+    // if the schedule has been paused, dequeue it from the cron loop.  It
+    // should not be fired.
+    if (schedule.paused) {
+      dequeue(id);
+    }
+
     // the updated flag is used to denote that a schedule has changed since being
     // added the queue.
     if (schedule && schedule.updated) {
@@ -91,10 +97,10 @@ function scan() {
   });
 
   // run through saved schedules and configure them if they haven't been configured
-  // yet
+  // yet, ignoring paused schedules
   schedules.data.forEach((schedule) => {
     const isScheduleConfigured = queue.get(schedule.id);
-    if (!isScheduleConfigured) {
+    if (!isScheduleConfigured && !schedule.paused) {
       enqueue(schedule);
     }
   });

--- a/locales/en/en.json
+++ b/locales/en/en.json
@@ -33,13 +33,17 @@
     "OVERVIEW" : "Overview",
     "SUBJECT": "Email Subject",
     "SUBMIT": "Create a Schedule",
-    "TITLE" : "Schedules"
+    "TITLE" : "Schedules",
+    "PAUSE_SUCCESS" : "Paused the schedule successfully",
+    "UNPAUSE_SUCCESS" : "Schedule has been reactivated successfully"
   },
 
   "ACTIONS": {
-    "TRIGGER": "Trigger",
-    "DELETE": "Delete",
-    "VIEW": "View"
+    "TRIGGER": "Run Schedule",
+    "DELETE": "Delete Schedule",
+    "VIEW": "View Schedule",
+    "PAUSE": "Pause Schedule",
+    "UNPAUSE": "Unpause Schedule"
   },
 
   "TOOLTIPS":{

--- a/locales/fr/fr.json
+++ b/locales/fr/fr.json
@@ -33,13 +33,17 @@
     "OVERVIEW" : "Détails",
     "SUBJECT": "Sujet",
     "SUBMIT": "Créer un horaire",
-    "TITLE" : "Les horaires"
+    "TITLE" : "Les horaires",
+    "PAUSE_SUCCESS" : "Interrompit l'horaire avec succès",
+    "UNPAUSE_SUCCESS" : "Redémarré l'horaire avec succès"
   },
 
   "ACTIONS": {
-    "TRIGGER": "Déclencher",
-    "DELETE": "Effacer",
-    "VIEW": "Voir"
+    "TRIGGER": "Exécuter l'horaire",
+    "DELETE": "Effacer l'horaire",
+    "VIEW": "Voir l'horaire",
+    "PAUSE": "Mettre en pause l'horaire",
+    "UNPAUSE": "Redémarrer l'horaire"
   },
 
   "TOOLTIPS":{

--- a/views/schedules/index.pug
+++ b/views/schedules/index.pug
@@ -26,7 +26,10 @@ block content
                   else
                     i ---
                 td(title=row.nextRunTime)
-                  i #{row.nextRunTimeLabel}
+                  if row.paused
+                    i.text-gray paused
+                  else
+                    i #{row.nextRunTimeLabel}
                 td(title=row.fmtDashboards) #{row.fmtDashboards}
                 td(title=row.userGroup.id) #{row.userGroup.displayName}
                 td(title=row.created) #{row.createdLabel}
@@ -35,19 +38,38 @@ block content
                     a(href="#", tabindex="0").btn.btn-link.dropdown-toggle #{t('SCHEDULES.ACTIONS')}
                       i.icon.icon-caret
 
-                    ul.menu
+                    ul(style="width:200px;").menu
 
                       li.menu-item
                         - const detailUrl = `/schedules/${row.id}/details`;
-                        a(href=detailUrl).text-primary #{t('ACTIONS.VIEW')}
+                        a(href=detailUrl).text-primary
+                          i.icon.icon-edit
+                          span(style="padding-left:0.6em;") #{t('ACTIONS.VIEW')}
 
                       li.menu-item
                         - const triggerUrl = `/schedules/${row.id}/trigger`;
-                        a(href=triggerUrl).text-success #{t('ACTIONS.TRIGGER')}
+                        a(href=triggerUrl).text-success
+                          i.icon.icon-refresh
+                          span(style="padding-left:0.6em;") #{t('ACTIONS.TRIGGER')}
+
+                      li.menu-item
+                        - const pauseUrl = `/schedules/${row.id}/pause`;
+                        if !row.paused
+                          a(href=pauseUrl).text-warning
+                            i.icon.icon-stop
+                            span(style="padding-left:0.6em;") #{t('ACTIONS.PAUSE')}
+                        else
+                          a(href=pauseUrl).text-primary
+                            i.icon.icon-check
+                            span(style="padding-left:0.6em;") #{t('ACTIONS.UNPAUSE')}
+
+                      li.divider
 
                       li.menu-item
                         - const deleteUrl = `/schedules/${row.id}/delete`;
-                        a(href=deleteUrl).text-error #{t('ACTIONS.DELETE')}
+                        a(href=deleteUrl).text-error
+                          i.icon.icon-delete
+                          span(style="padding-left:0.6em;") #{t('ACTIONS.DELETE')}
 
         unless schedules.length
           .empty

--- a/views/schedules/index.pug
+++ b/views/schedules/index.pug
@@ -14,7 +14,7 @@ block content
               th #{t('SCHEDULES.DASHBOARDS')}
               th #{t('SCHEDULES.GROUP')}
               th #{t('SCHEDULES.CREATED')}
-              th(colspan=3) #{t('SCHEDULES.ACTIONS')}
+              th #{t('SCHEDULES.ACTIONS')}
           tbody
             each row in schedules
               tr
@@ -31,15 +31,23 @@ block content
                 td(title=row.userGroup.id) #{row.userGroup.displayName}
                 td(title=row.created) #{row.createdLabel}
                 td
-                  - const detailUrl = `/schedules/${row.id}/details`;
-                  a(href=detailUrl, data-tooltip=t('TOOLTIPS.VIEW')).tooltip #{t('ACTIONS.VIEW')}
-                td
-                  - const triggerUrl = `/schedules/${row.id}/trigger`;
-                  a(href=triggerUrl, data-tooltip=t('TOOLTIPS.TRIGGER')).tooltip #{t('ACTIONS.TRIGGER')}
-                td
-                  - const url = `/schedules/${row.id}/delete`;
-                  a(href=url, data-tooltip=t('TOOLTIPS.DELETE')).tooltip.tooltip-left #{t('ACTIONS.DELETE')}
+                  .dropdown.dropdown-right
+                    a(href="#", tabindex="0").btn.btn-link.dropdown-toggle #{t('SCHEDULES.ACTIONS')}
+                      i.icon.icon-caret
 
+                    ul.menu
+
+                      li.menu-item
+                        - const detailUrl = `/schedules/${row.id}/details`;
+                        a(href=detailUrl).text-primary #{t('ACTIONS.VIEW')}
+
+                      li.menu-item
+                        - const triggerUrl = `/schedules/${row.id}/trigger`;
+                        a(href=triggerUrl).text-success #{t('ACTIONS.TRIGGER')}
+
+                      li.menu-item
+                        - const deleteUrl = `/schedules/${row.id}/delete`;
+                        a(href=deleteUrl).text-error #{t('ACTIONS.DELETE')}
 
         unless schedules.length
           .empty


### PR DESCRIPTION
This commit implements a feature to pause schedules and prevent them from being sent out to users.  To do this, I first added a dropdown menu to the interface, then went ahead with the pause toggle.  The text is stateful so it updates itself to say "pause" or "unpause" in the various languages supported.

Closes #11.