### PR TITLE
Release 2.1.2

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -96,7 +96,7 @@ async function runScheduledTask(schedule) {
     debug('Email sent');
   } catch (err) {
     eventer.emit('event', `Whoops!  We hit the following error: ${err.toString()}`);
-    throw err;
+    await crawler.panic();
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@ima-worldhealth/coral": "^1.4.0",
     "@ima-worldhealth/cron-scheduler": "^1.2.1",
     "@ima-worldhealth/dhis2-api": "^0.0.6",
-    "@ima-worldhealth/dhis2-crawler": "^0.1.0",
+    "@ima-worldhealth/dhis2-crawler": "^0.2.0",
     "better-sqlite3": "^6.0.1",
     "connect-redis": "^4.0.0",
     "cron-parser": "^2.7.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "release-it": "^12.4.3"
   },
   "name": "@ima-worldhealth/sunfish",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A webapp for configuring DHIS2 email reports",
   "main": "index.js",
   "directories": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,17 +66,17 @@
     qs "^6.6.0"
     shortid "^2.2.14"
 
-"@ima-worldhealth/dhis2-crawler@^0.1.0":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@ima-worldhealth/dhis2-crawler/-/dhis2-crawler-0.1.1.tgz#6d50fcd266e8b73b848434f1128295df95e26def"
-  integrity sha512-AE7UjMHzVqJ2iY0COXchlo3c6kHoibR9IjOPkss3MzduRoaCU8sYKF5mpNS/wjGQ3feGbfvg5Nw7dXqohuGx9A==
+"@ima-worldhealth/dhis2-crawler@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@ima-worldhealth/dhis2-crawler/-/dhis2-crawler-0.2.0.tgz#b16507f848e91d9676e0ae4afad05b61784c9ac0"
+  integrity sha512-HvBWg9zpYHIQ2JIj0TsILb6S4KK6kZShAOhWJXNNUmqrPWooJ4Ye3UOCvKO3vg+qye2dFpwGPxFIR83stH4wAA==
   dependencies:
     debug "^4.1.1"
     delay "^4.1.0"
     html2canvas "^1.0.0-rc.5"
-    puppeteer-core "^1.12.2"
+    puppeteer-core "^2.0.0"
     save-svg-as-png "^1.4.11"
-    tempy "^0.3.0"
+    tempy "^0.4.0"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -1182,11 +1182,6 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-crypto-random-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
-  integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -2427,14 +2422,6 @@ http-proxy-agent@^2.1.0:
   dependencies:
     agent-base "4"
     debug "3.1.0"
-
-https-proxy-agent@^2.2.1:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
-  integrity sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
-  dependencies:
-    agent-base "^4.3.0"
-    debug "^3.1.0"
 
 https-proxy-agent@^3.0.0:
   version "3.0.1"
@@ -4132,15 +4119,17 @@ pupa@^2.0.1:
   dependencies:
     escape-goat "^2.0.0"
 
-puppeteer-core@^1.12.2:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-1.20.0.tgz#cfad0c7cbb6e9bb0d307c6e955e5c924134bbeb5"
-  integrity sha512-akoSCMDVv6BFd/4+dtW6mVgdaRQhy/cmkGzXcx9HAXZqnY9zXYbsfoXMiMpwt3+53U9zFGSjgvsi0mDKNJLfqg==
+puppeteer-core@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-2.1.1.tgz#e9b3fbc1237b4f66e25999832229e9db3e0b90ed"
+  integrity sha512-n13AWriBMPYxnpbb6bnaY5YoY6rGj8vPLrz6CZF3o0qJNEwlcfJVxBzYZ0NJsQ21UbdJoijPCDrM++SUVEz7+w==
   dependencies:
+    "@types/mime-types" "^2.1.0"
     debug "^4.1.0"
     extract-zip "^1.6.6"
-    https-proxy-agent "^2.2.1"
+    https-proxy-agent "^4.0.0"
     mime "^2.0.3"
+    mime-types "^2.1.25"
     progress "^2.0.1"
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
@@ -4983,24 +4972,10 @@ tar@4.4.10:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-temp-dir@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
-  integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
-
 temp-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
   integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
-
-tempy@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.3.0.tgz#6f6c5b295695a16130996ad5ab01a8bd726e8bf8"
-  integrity sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==
-  dependencies:
-    temp-dir "^1.0.0"
-    type-fest "^0.3.1"
-    unique-string "^1.0.0"
 
 tempy@^0.4.0:
   version "0.4.0"
@@ -5118,7 +5093,7 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
-type-fest@^0.3.0, type-fest@^0.3.1:
+type-fest@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
   integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
@@ -5182,13 +5157,6 @@ uid-safe@~2.1.5:
   integrity sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==
   dependencies:
     random-bytes "~1.0.0"
-
-unique-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
-  integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
-  dependencies:
-    crypto-random-string "^1.0.0"
 
 unique-string@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Bumps the dhis2-crawler to avoid leaving chromium-browser instances running after an error.