### PR TITLE
fix(ci): trim dependabot commit message

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,7 @@
+status = [
+  "continuous-integration/travis-ci/push"
+]
+
+timeout_sec = 14400
+
+cut_body_after = "</details>"


### PR DESCRIPTION
Fixes the dependabot merge in bors to trim out any text so that we don't
get directives not meant for Travis in the commit result.