### PR TITLE
fix(reports): add timestamp to report name

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -63,7 +63,6 @@ async function runScheduledTask(schedule) {
       options.skipGraphs = false;
     }
 
-    // TODO - is the multiple dashboards, or just one dashboard?
     const components = await crawler.downloadDashboardComponents(dashboards, options);
 
     // terminate the chrome browser
@@ -102,6 +101,7 @@ async function runScheduledTask(schedule) {
 
     debug('Composed email and sending...');
     const userEmailAddresses = users.data.users.map((user) => user.email);
+
     eventer.emit('event', `Sending email to ${userEmailAddresses.length} users.`);
     await mail.send(userEmailAddresses, schedule.subject, email, attachments, randint);
 

--- a/lib/scribe.js
+++ b/lib/scribe.js
@@ -49,8 +49,14 @@ function humanReadableDateFormat(date) {
   return `${year}-${month}-${day}`;
 }
 
+function getTimestamp() {
+  return new Date()
+    .replace('T', ' ')
+    .replace(/:[0-9]+\.[0-9]+Z/, '');
+}
+
 exports.render = async (label, report) => {
-  const filename = path.join(TEMP_DIR, `${label}-${report.date}.pdf`);
+  const filename = path.join(TEMP_DIR, `${label}-${getTimeStamp()}.pdf`);
 
   // check if file is already defined
   try {


### PR DESCRIPTION
Adds a timestamp to the report attachment name.  The previous version rendered undefined instead of the timestamp.
