### PR TITLE
feat: replace sendgrid w/ custom SMTP transport

### DIFF
--- a/lib/mail.js
+++ b/lib/mail.js
@@ -107,6 +107,14 @@ async function prepareAttachment(filePath) {
   };
 }
 
+function prepareAttachmentSMTP(filePath) {
+  debug(`peparing attachment: ${filePath}`);
+  return {
+    filename : path.parse(filePath).base,
+    path : filePath,
+  };
+}
+
 function compose(schedule, attachments) {
   const { subject, body } = schedule;
 
@@ -134,11 +142,16 @@ async function send(addresses, subject, body, attachments) {
   // remove undefined BCC addresses.
   const bcc = addresses.filter((addr) => !!addr);
 
+  // use different attachment functions
+  const attachmentFn = hasSendGridCredentials
+    ? prepareAttachment
+    : prepareAttachmentSMTP;
+
   const data = {
     subject,
     bcc,
     text : body,
-    attachments : await Promise.all(attachments.map(prepareAttachment)),
+    attachments : await Promise.all(attachments.map(attachmentFn)),
     from : SMTP_USERNAME || APP_EMAIL,
     to : [DEVELOPERS_EMAIL, SMTP_USERNAME],
   };

--- a/lib/mail.js
+++ b/lib/mail.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 /**
  * @overview mail
  *
@@ -19,7 +20,14 @@ const {
   APP_EMAIL,
   APP_NAME,
   APP_URL,
+
+  // if using Sendgrid
   SENDGRID_API_KEY,
+
+  // if using a custom SMTP Server (mail in a box)
+  SMTP_HOST,
+  SMTP_USERNAME,
+  SMTP_PASSWORD,
 } = process.env;
 
 const path = require('path');
@@ -27,9 +35,45 @@ const fs = require('fs');
 const dayjs = require('dayjs');
 const debug = require('debug')('sunfish:mail');
 
-const mailer = require('@sendgrid/mail');
+const hasSendGridCredentials = SENDGRID_API_KEY !== undefined;
 
-mailer.setApiKey(SENDGRID_API_KEY);
+function setupSendGridTransport() {
+  debug('Using SendGrid for email transport.');
+  const mailer = require('@sendgrid/mail');
+  mailer.setApiKey(SENDGRID_API_KEY);
+  return mailer;
+}
+
+function setupSMTPTransport() {
+  debug(`Using ${SMTP_HOST} for email transport.`);
+  const nodemailer = require('nodemailer');
+  const transport = nodemailer.createTransport({
+    host : SMTP_HOST,
+    port : 587,
+    secure : false,
+    auth : { user : SMTP_USERNAME, pass : SMTP_PASSWORD },
+  });
+
+  // check SMTP credentials
+  transport.verify((err) => {
+    if (err) {
+      debug(`Error connecting to ${SMTP_HOST}.`);
+      debug(`Error: ${JSON.stringify(err)}`);
+    } else {
+      debug(`${SMTP_HOST} is ready to accept connections.`);
+    }
+  });
+
+  // alias sendMail() as send();
+  transport.send = transport.sendMail;
+  return transport;
+}
+
+function setupMailTransport() {
+  return hasSendGridCredentials
+    ? setupSendGridTransport()
+    : setupSMTPTransport();
+}
 
 const formatAsList = (file, idx) => `${idx + 1}.  ${path.parse(file).name}`;
 const r = (str) => new RegExp(str, 'g');
@@ -50,7 +94,7 @@ function template(text, data) {
     .replace(r('{{dashboards}}'), data.dashboards.map(formatAsList).join('\n'));
 }
 
-// prepares the file for Sendgrid.
+// prepares the file for SendGrid.
 async function prepareAttachment(filePath) {
   debug(`reading attachment: ${filePath}`);
   const file = await fs.promises.readFile(filePath);
@@ -58,6 +102,7 @@ async function prepareAttachment(filePath) {
     filename : path.parse(filePath).base,
     content : file.toString('base64'),
     type : 'application/pdf',
+    contentType : 'application/pdf',
     disposition : 'attachment',
   };
 }
@@ -82,6 +127,9 @@ function compose(schedule, attachments) {
   return template(body, data);
 }
 
+// setup mail transport
+const mailer = setupMailTransport();
+
 async function send(addresses, subject, body, attachments) {
   // remove undefined BCC addresses.
   const bcc = addresses.filter((addr) => !!addr);
@@ -91,11 +139,11 @@ async function send(addresses, subject, body, attachments) {
     bcc,
     text : body,
     attachments : await Promise.all(attachments.map(prepareAttachment)),
-    from : APP_EMAIL,
-    to : DEVELOPERS_EMAIL,
+    from : SMTP_USERNAME || APP_EMAIL,
+    to : [DEVELOPERS_EMAIL, SMTP_USERNAME],
   };
 
-  debug(`sending an email via sendgrid to ${data.to} from ${data.from} with BCCs (${data.bcc.join(',')}).`);
+  debug(`sending an email to ${data.to} from ${data.from} with BCCs (${data.bcc.join(',')}).`);
   await mailer.send(data);
   debug('mail sent successfully');
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "i18next-express-middleware": "^2.0.0",
     "i18next-node-fs-backend": "^2.1.1",
     "ioredis": "^4.14.0",
+    "nodemailer": "^6.4.10",
     "normalize.css": "^8.0.1",
     "p-retry": "^4.2.0",
     "passport": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "release-it": "^13.0.0"
   },
   "name": "@ima-worldhealth/sunfish",
-  "version": "2.5.3",
+  "version": "3.0.0",
   "description": "A webapp for configuring DHIS2 email reports",
   "main": "index.js",
   "directories": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3298,6 +3298,11 @@ node-fetch@^2.3.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
+nodemailer@^6.4.10:
+  version "6.4.10"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.4.10.tgz#f4c8dc7991c57f41fd081bef224ef01f7065143d"
+  integrity sha512-j+pS9CURhPgk6r0ENr7dji+As2xZiHSvZeVnzKniLOw1eRAyM/7flP0u65tCnsapV8JFu+t0l/5VeHsCZEeh9g==
+
 noop-logger@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"


### PR DESCRIPTION
Allows SendGrid to be replaced with a custom SMTP transport.  In this case, [mail-in-a-box](https://mailinabox.email/guide.html).

🚀 Let's release @ima-worldhealth/sunfish (currently at 2.5.3)


Changelog:
* chore: use different attachment fns (36f6d73)
* feat: replace sendgrid w/ custom SMTP transport (76d0800)
* Merge #196 (6968c59)
* chore(deps-dev): bump ava from 3.10.1 to 3.11.0 (de28082)
* Merge #195 (f1da4d9)
* Merge #194 (d93d971)
* chore(deps): bump i18next from 19.6.2 to 19.6.3 (eec8f64)
* chore(deps-dev): bump release-it from 13.6.5 to 13.6.6 (fd10a00)
* Merge #193 (7ba730a)
* chore(deps): bump @ima-worldhealth/cron-scheduler from 1.4.0 to 1.5.0 (4e063c2)
* Merge #191 (f964490)
* chore(deps): bump dayjs from 1.8.29 to 1.8.30 (d8962a0)
* Merge #187 (36e39b5)
* Merge #189 (6a3df2b)
* Merge #188 (345e915)
* chore(deps-dev): bump eslint from 7.4.0 to 7.5.0 (67f0255)
* chore(deps): bump tempy from 0.5.0 to 0.6.0 (9d1843c)
* chore(deps): bump delay from 4.3.0 to 4.4.0 (bd724cf)
* Merge #186 (e8ae3d3)
* chore(deps): bump i18next from 19.6.1 to 19.6.2 (9972e67)

